### PR TITLE
Add `sd_product` tag to auto-gen pr. layout

### DIFF
--- a/layouts/auto_generated_product.tpl
+++ b/layouts/auto_generated_product.tpl
@@ -6,6 +6,8 @@
   {% include "html-head" items_page: true %}
   {% include "edicy-tools-variables" %}
   {% include "edicy-tools-styles" %}
+
+  {% sd_product %}
 </head>
 
 {%- capture bottom_content_html -%}


### PR DESCRIPTION
Include `sd_product` tag in Auto-rendered Product layout to render out product structured data.

Closes #127 